### PR TITLE
Adds support for suspending and restarting actions

### DIFF
--- a/oliphaunt/action.cpp
+++ b/oliphaunt/action.cpp
@@ -1,0 +1,27 @@
+#include "action.h"
+
+void Action::start(ActionArgs *args) {        
+    if(proc_status != STOPPED) return;
+    
+    proc_status = RUNNING;
+    setup(args);
+}
+
+void Action::stop() {
+    if(proc_status != RUNNING) return;
+    
+    cleanup();
+    proc_status = STOPPED;
+}
+
+void Action::suspend() {
+    if(proc_status != RUNNING) return;
+    
+    proc_status = SUSPENDED;
+}
+
+void Action::restart() {        
+    if(proc_status != SUSPENDED) return;
+    
+    proc_status = RUNNING;
+}

--- a/oliphaunt/action.h
+++ b/oliphaunt/action.h
@@ -19,13 +19,26 @@ typedef struct ActionArgsStruct {
 #define ARGS(ARG_STRUCT, IDX, ARG_FIELD) ARG_STRUCT.list[IDX].ARG_FIELD
 #define ARGSP(ARG_STRUCT_PTR, IDX, ARG_FIELD) ARG_STRUCT_PTR->list[IDX].ARG_FIELD
 
+typedef enum {
+    STOPPED,
+    SUSPENDED,
+    RUNNING,
+} ProcessStatus;
+
 /*
     Encapsulates an action that the robot needs to perform into a group of callbacks.
     Each of the public methods will be called by the ActionManager at the appropriate time.
 */
 class Action {
+    protected:
+        ProcessStatus proc_status;
+
     public:
         //const char* name = "Action"; //for debugging
+        
+        Action() { proc_status = STOPPED; }
+        
+        ProcessStatus getProcessStatus() { return proc_status; }
         
         // Called once, when the task is first made active.
         virtual void setup(ActionArgs *args) {}
@@ -38,6 +51,12 @@ class Action {
         
         // Called once, after the task has been determined to be finished.
         virtual void cleanup() {}
+        
+        // These should only be called by the the action scheduler, really
+        void start(ActionArgs *args);
+        void stop();
+        void suspend();
+        void restart();
 };
 
 /*

--- a/oliphaunt/actionqueue.cpp
+++ b/oliphaunt/actionqueue.cpp
@@ -66,6 +66,23 @@ void forceNextAction(Action *next, ActionArgs *args) {
     currentAction->setup(args);
 }
 
+/** Suspending and Restarting **/
+
+Action* suspendCurrentAction() {
+    if(!currentAction) return NULL;
+
+    Action *suspended = currentAction;
+    currentAction = NULL;
+    return suspended;
+}
+
+//Basically like forceNextAction but doesn't call setup.
+//Will kill the current action unless it has been suspended first.
+void restartAction(Action *action) {
+    _killCurrentAction();
+    currentAction = action;
+}
+
 /** Queueing actions **/
 
 //Gets the index of the last item in the queue

--- a/oliphaunt/actionqueue.h
+++ b/oliphaunt/actionqueue.h
@@ -11,6 +11,12 @@ typedef struct ActionQueueItemStruct {
 
 #define ACTION_QUEUE_SIZE 20
 
+/*
+    Note: Actions themselves are not stored in the queue, only pointers.
+    Memory and lifetime of Actions should be handled elsewhere.
+    ActionArgs are however stored in the queue.
+*/
+
 extern Action *currentAction;
 
 void initQueue();
@@ -18,9 +24,27 @@ void processMain();
 Action* getCurrentAction();
 boolean queueIsEmpty();
 boolean queueIsFull();
+
+//number of items in the queue, does not count the current action
 int queueLength();
+
+//Forces the current action to stop, and starts the given one, skipping the queue.
+//Will kill the current action unless it has been suspended first.
 void forceNextAction(Action *next, ActionArgs *args);
+
+//Adds to the front of the queue, essentially
 void setNextAction(Action *next, ActionArgs *args);
+
+//Adds to the end of the queue
 void queueAction(Action *action, ActionArgs *args);
+
+//Returns the action that has been suspended. 
+//Suspended actions should not be put back on the queue ATM. Use restartAction() instead.
+//Support for queueing suspended actions should be easy to add if it is needed.
+Action* suspendCurrentAction();
+
+//Basically like forceNextAction but doesn't call setup.
+//Will kill the current action unless it has been suspended first.
+void restartAction(Action *action);
 
 #endif

--- a/oliphaunt/actionqueue.h
+++ b/oliphaunt/actionqueue.h
@@ -4,12 +4,12 @@
 #ifndef _ACTIONQUEUE_H
 #define _ACTIONQUEUE_H
 
+#define ACTION_QUEUE_SIZE 20
+
 typedef struct ActionQueueItemStruct {
     Action *action;
     ActionArgs args;
 } ActionQueueItem;
-
-#define ACTION_QUEUE_SIZE 20
 
 /*
     Note: Actions themselves are not stored in the queue, only pointers.
@@ -39,12 +39,9 @@ void setNextAction(Action *next, ActionArgs *args);
 void queueAction(Action *action, ActionArgs *args);
 
 //Returns the action that has been suspended. 
-//Suspended actions should not be put back on the queue ATM. Use restartAction() instead.
-//Support for queueing suspended actions should be easy to add if it is needed.
 Action* suspendCurrentAction();
 
-//Basically like forceNextAction but doesn't call setup.
-//Will kill the current action unless it has been suspended first.
-void restartAction(Action *action);
+//Returns the action that has been stopped.
+Action* killCurrentAction();
 
 #endif


### PR DESCRIPTION
At the moment, suspended actions should not be put back on the queue. Use restartAction() instead.
Support for queuing suspended actions should be easy to add if it is needed.
